### PR TITLE
* Add client-side support for showing inactive regions

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,12 @@
 					"default": false,
 					"description": "Syntax will be checked when file opens or saves"
 				},
+				"pascalLanguageServer.initializationOptions.checkInactiveRegions": {
+					"type": "boolean",
+					"scope": "application",
+					"default": true,
+					"description": "Mark inactive regions based on conditional compilation directives"
+				},
 				"pascalLanguageServer.initializationOptions.publishDiagnostics": {
 					"type": "boolean",
 					"scope": "application",


### PR DESCRIPTION
Ryan

This is the VS-Code client side support for showing inactive regions in the code, see my merge request in 
pascal language server for the server-side support